### PR TITLE
Bump go-datastore to 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   },
   "gxDependencies": [
     {
-      "hash": "QmaRb5yNXKonhbkpNxNawoydk4N6es6b4fPj19sjEKsh5D",
+      "hash": "Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM",
       "name": "go-datastore",
-      "version": "3.1.0"
+      "version": "3.4.1"
     }
   ],
   "gxVersion": "0.14.0",


### PR DESCRIPTION
Updating to match `go-datastore` version from `go-ipfs@0.4.19-dev`