### PR TITLE
Don't drop errors

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -227,7 +227,7 @@ func parseError(err error) error {
 	if s3Err, ok := err.(awserr.Error); ok && s3Err.Code() == s3.ErrCodeNoSuchKey {
 		return ds.ErrNotFound
 	}
-	return nil
+	return err
 }
 
 type s3Batch struct {


### PR DESCRIPTION
As things stand, if a S3 API call fails for any reason other than `s3.ErrCodeNoSuchKey` the error is simply ignored.

This change simply returns the error for the caller to handle