### PR TITLE
allow local testing of the s3 datastore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+ localstack:
+    image: localstack/localstack
+    environment:
+      - SERVICES=s3
+    ports:
+      - 4572:4572

--- a/s3_test.go
+++ b/s3_test.go
@@ -1,15 +1,39 @@
 package s3ds
 
 import (
+	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
 	dstest "github.com/ipfs/go-datastore/test"
 )
 
 func TestSuite(t *testing.T) {
-	s3ds, err := NewS3Datastore(Config{})
+	// run docker-compose up in this repo in order to get a local
+	// s3 running on port 4572
+	config := Config{}
+	_, hasLocalS3 := os.LookupEnv("LOCAL_S3")
+	if hasLocalS3 {
+		config = Config{
+			RegionEndpoint: "http://localhost:4572",
+			Bucket:         "localBucketName",
+			Region:         "us-east-1",
+			AccessKey:      "localonlyac",
+			SecretKey:      "localonlysk",
+		}
+	}
+
+	s3ds, err := NewS3Datastore(config)
 	if err != nil {
 		t.Error(err)
+	}
+
+	if hasLocalS3 {
+		err = devMakeBucket(s3ds.S3, "localBucketName")
+		if err != nil {
+			t.Error(err)
+		}
 	}
 
 	t.Run("basic operations", func(t *testing.T) {
@@ -21,4 +45,12 @@ func TestSuite(t *testing.T) {
 	t.Run("many puts and gets, query", func(t *testing.T) {
 		dstest.SubtestManyKeysAndQuery(t, s3ds)
 	})
+}
+
+func devMakeBucket(s3obj *s3.S3, bucketName string) error {
+	_, err := s3obj.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+
+	return err
 }


### PR DESCRIPTION
This is a small PR to allow local testing. If you `export LOCAL_S3=true` your tests will run against a local s3 on port 4572. Additionally, it adds a (very) small docker-compose to provide a local s3 for you.