### PR TITLE
partially fix build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
+# Force Go Modules
+GO111MODULE = on
+
 GOCC ?= go
+GOFLAGS ?=
+
+# make reproducable
+GOFLAGS += -asmflags=all=-trimpath="$(GOPATH)" -gcflags=all=-trimpath="$(GOPATH)"
 
 # If set, override the install location for plugins
 IPFS_PATH ?= $(HOME)/.ipfs
@@ -15,7 +22,7 @@ go.mod: FORCE
 FORCE:
 
 s3plugin.so: plugin/main.go go.mod
-	$(GOCC) build -buildmode=plugin -i -o "$@" "$<"
+	$(GOCC) build $(GOFLAGS) -buildmode=plugin -o "$@" "$<"
 	chmod +x "$@"
 
 build: s3plugin.so

--- a/set-target.sh
+++ b/set-target.sh
@@ -10,17 +10,26 @@ PKG=github.com/ipfs/go-ipfs
 
 if [[ "$VERSION" == /* ]]; then
     # Build against a local repo
-    PKGDIR="$VERSION"
+    MODFILE="$VERSION/go.mod"
     $GOCC mod edit -replace "github.com/ipfs/go-ipfs=$VERSION"
 else
     $GOCC mod edit -dropreplace=github.com/ipfs/go-ipfs
     # Resolve the exact version/package name
-    PKGDIR="$(go list -f '{{.Dir}}' -m "$PKG@$VERSION")"
+    MODFILE="$(go list -f '{{.GoMod}}' -m "$PKG@$VERSION")"
     resolvedver="$(go list -f '{{.Version}}' -m "$PKG@$VERSION")"
 
     # Update to that version.
     $GOCC get $PKG@$resolvedver
 fi
 
-$GOCC mod edit $(cd "$PKGDIR" && go list -f '-require={{.Path}}@{{.Version}}{{if .Replace}} -replace={{.Path}}@{{.Version}}={{.Replace}}{{end}}' -m all | tail -n+2)
+TMP="$(mktemp -d)"
+trap "$(printf 'rm -rf "%q"' "$TMP")" EXIT
+
+(
+    cd "$TMP"
+    cp "$MODFILE" "go.mod"
+    go list -f '-require={{.Path}}@{{.Version}}{{if .Replace}} -replace={{.Path}}@{{.Version}}={{.Replace}}{{end}}' -m all | tail -n+2  > args
+)
+
+$GOCC mod edit $(cat "$TMP/args")
 $GOCC mod tidy


### PR DESCRIPTION
1. Don't build with `-i`. It tries to rebuild go packages for some reason.
2. Don't run `go list` in-place. It tries to edit the go mod file.
3. Strip the go path when building.