### PR TITLE
query: add support for filters/orders

### DIFF
--- a/s3_test.go
+++ b/s3_test.go
@@ -26,13 +26,13 @@ func TestSuite(t *testing.T) {
 
 	s3ds, err := NewS3Datastore(config)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if hasLocalS3 {
 		err = devMakeBucket(s3ds.S3, "localBucketName")
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	}
 	dstest.SubtestAll(t, s3ds)

--- a/s3_test.go
+++ b/s3_test.go
@@ -35,16 +35,7 @@ func TestSuite(t *testing.T) {
 			t.Error(err)
 		}
 	}
-
-	t.Run("basic operations", func(t *testing.T) {
-		dstest.SubtestBasicPutGet(t, s3ds)
-	})
-	t.Run("not found operations", func(t *testing.T) {
-		dstest.SubtestNotFounds(t, s3ds)
-	})
-	t.Run("many puts and gets, query", func(t *testing.T) {
-		dstest.SubtestManyKeysAndQuery(t, s3ds)
-	})
+	dstest.SubtestAll(t, s3ds)
 }
 
 func devMakeBucket(s3obj *s3.S3, bucketName string) error {


### PR DESCRIPTION
fixes #5