### PR TITLE
make sure Put doesn't return ErrNotFound

### DIFF
--- a/s3_test.go
+++ b/s3_test.go
@@ -26,13 +26,13 @@ func TestSuite(t *testing.T) {
 
 	s3ds, err := NewS3Datastore(config)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if hasLocalS3 {
 		err = devMakeBucket(s3ds.S3, "localBucketName")
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	}
 


### PR DESCRIPTION
This PR make sure that `Put` is not able to return `ds.ErrNotFound`, whatever AWS return as error.

I don't think it's actually happening, but at least it make sure that my problem is not here.