### PR TITLE
fix Query badly handling prefix

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -156,6 +156,9 @@ func (s *S3Bucket) Query(q dsq.Query) (dsq.Results, error) {
 		return nil, fmt.Errorf("s3ds: filters or orders are not supported")
 	}
 
+	// S3 store a "/foo" key as "foo" so we need to trim the leading "/"
+	q.Prefix = strings.TrimPrefix(q.Prefix, "/")
+
 	limit := q.Limit + q.Offset
 	if limit == 0 || limit > listMax {
 		limit = listMax


### PR DESCRIPTION
S3 store a "/foo" key as "foo" so we need to trim the leading "/", otherwise nothing is returned, which tend to break a few things in go-ipfs.

The tests were passing because they use `""` and not `"/"`