### PR TITLE
Update Datastore Interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,11 @@ module github.com/ipfs/go-ds-s3
 
 require (
 	github.com/aws/aws-sdk-go v1.25.7
-	github.com/ipfs/go-datastore v0.2.0
+	github.com/ipfs/go-datastore v0.3.1
 	github.com/ipfs/go-ipfs v0.4.22
 )
 
-go 1.11
+go 1.12
 
 replace github.com/go-critic/go-critic v0.0.0-20181204210945-ee9bf5809ead => github.com/go-critic/go-critic v0.4.0
 

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/ipfs/go-datastore v0.0.3 h1:/eP3nMDmLzMJNoWSSYvEkmMTTrm9FFCN+JraP9Ndl
 github.com/ipfs/go-datastore v0.0.3/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=
 github.com/ipfs/go-datastore v0.0.5 h1:q3OfiOZV5rlsK1H5V8benjeUApRfMGs4Mrhmr6NriQo=
 github.com/ipfs/go-datastore v0.0.5/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=
-github.com/ipfs/go-datastore v0.2.0 h1:5Wjw6YXzZmtqU1MSrlws64+oLmSqea7gEajTcJickh8=
-github.com/ipfs/go-datastore v0.2.0/go.mod h1:w38XXW9kVFNp57Zj5knbKWM2T+KOZCGDRVNdgPHtbHw=
+github.com/ipfs/go-datastore v0.3.1 h1:SS1t869a6cctoSYmZXUk8eL6AzVXgASmKIWFNQkQ1jU=
+github.com/ipfs/go-datastore v0.3.1/go.mod h1:w38XXW9kVFNp57Zj5knbKWM2T+KOZCGDRVNdgPHtbHw=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ds-badger v0.0.2 h1:7ToQt7QByBhOTuZF2USMv+PGlMcBC7FW7FdgQ4FCsoo=

--- a/s3.go
+++ b/s3.go
@@ -98,6 +98,10 @@ func (s *S3Bucket) Put(k ds.Key, value []byte) error {
 	return err
 }
 
+func (s *S3Bucket) Sync(prefix ds.Key) error {
+	return nil
+}
+
 func (s *S3Bucket) Get(k ds.Key) ([]byte, error) {
 	resp, err := s.S3.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(s.Bucket),


### PR DESCRIPTION
Per ipfs/go-datastore#140 the Datastore interface is being updated to support asynchronous writes.

This PR should be approved before the above PR is merged. After ipfs/go-datastore#140 is merged then this PR should have its go.mod updated and merged.