### PR TITLE
doc: document release branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ This is an implementation of the datastore interface backed by amazon s3.
 
 You must build the plugin with the *exact* version of go used to build the go-ipfs binary you will use it with. You can find the go version for go-ipfs builds from dist.ipfs.io in the build-info file, e.g. https://dist.ipfs.io/go-ipfs/v0.4.22/build-info or by running `ipfs version --all`.
 
-In addition to needing the exact version of go, you need to correctly specify the exact version of go-ipfs.
+In addition to needing the exact version of go, you need to build the correct version of this plugin.
 
-* If you installed go-ipfs via ipfs-update (or from dist.ipfs.io), you'll need to build this plugin with `make IPFS_VERSION=version`.
-* If you installed go-ipfs via `go get github.com/ipfs/go-ipfs/cmd/ipfs@$SOME_VERSION`, you'll need to build this plugin with `make IPFS_VERSION=$SOME_VERSION`.
-* If you installed go-ipfs by running `make` in the go-ipfs source, you'll need to build this plugin with `IPFS_VERSION=/path/to/go-ipfs/source`.
+* To build against a released version of go-ipfs, checkout the `release/v$VERSION` branch and build.
+* To build against a custom (local) build of go-ipfs, run `make IPFS_VERSION=/path/to/go-ipfs/source`.
 
 You can then install it into your local IPFS repo by running `make install`.
 


### PR DESCRIPTION
The current release doesn't actually work with go-ipfs 0.4.22 as it uses a newer version of go-datastore. Instead of playing games with go mod, tell users to checkout a known working branch.