### PR TITLE
Add credentials endpoint provider, for e.g. ECS/Fargate

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -32,6 +32,10 @@ const (
 	deleteMax = 1000
 
 	defaultWorkers = 100
+
+	// credsRefreshWindow, subtracted from the endpointcred's expiration time, is the
+	// earliest time the endpoint creds can be refreshed.
+	credsRefreshWindow = 2 * time.Minute
 )
 
 type S3Bucket struct {
@@ -73,7 +77,7 @@ func NewS3Datastore(conf Config) (*S3Bucket, error) {
 		&credentials.SharedCredentialsProvider{},
 		&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(sess)},
 		endpointcreds.NewProviderClient(*d.Config, d.Handlers, conf.CredentialsEndpoint,
-			func(p *endpointcreds.Provider) { p.ExpiryWindow = 5 * time.Minute },
+			func(p *endpointcreds.Provider) { p.ExpiryWindow = credsRefreshWindow },
 		),
 	})
 


### PR DESCRIPTION
Adds an AWS credentials provider in the credentials chain. Without it tasks running in ECS/Fargate will have their credentials revoked after a relatively short period of time. 

(A container task can then set `CredentialsEndpoint` to `http://169.254.170.2${REL_PATH}` where `${REL_PATH}` comes from one of the default AWS provided environment variables, e.g. `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html for details.)