### PR TITLE
Edit piping into file to append, not truncate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ As go plugins can be finicky to correctly compile and install, you may want to c
 > go get github.com/ipfs/go-ds-s3@latest
 
 # Add the plugin to the preload list.
-> echo "s3ds github.com/ipfs/go-ds-s3/plugin 0" > plugin/loader/preload_list
+> echo "s3ds github.com/ipfs/go-ds-s3/plugin 0" >> plugin/loader/preload_list
 
 # Rebuild go-ipfs with the plugin
 > make build


### PR DESCRIPTION
This little change will cause it so that the ipfs daemon wont emit small errors like `Error: unknown datastore type: levelds`