### PR TITLE
chore: fixup tests and ensure go vet and staticcheck pass

### DIFF
--- a/s3_test.go
+++ b/s3_test.go
@@ -17,7 +17,7 @@ func TestSuite(t *testing.T) {
 	if hasLocalS3 {
 		config = Config{
 			RegionEndpoint: "http://localhost:4566",
-			Bucket:         "localBucketName",
+			Bucket:         "localbucketname",
 			Region:         "us-east-1",
 			AccessKey:      "localonlyac",
 			SecretKey:      "localonlysk",
@@ -30,7 +30,7 @@ func TestSuite(t *testing.T) {
 	}
 
 	if hasLocalS3 {
-		err = devMakeBucket(s3ds.S3, "localBucketName")
+		err = devMakeBucket(s3ds.S3, "localbucketname")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Test was failing because s3 buckets cannot contain uppercase letters