### PR TITLE
Setup CI integration tests with local S3 instance 

### DIFF
--- a/.github/workflows/go-test-integration.yml
+++ b/.github/workflows/go-test-integration.yml
@@ -1,0 +1,20 @@
+on: [ push, pull_request ]
+
+name: Go Integration Test
+
+jobs:
+  it-local:
+    name: local s3
+    runs-on: ubuntu-latest
+    env:
+      LOCAL_S3: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+      - name: Start local S3
+        run: docker-compose up -d
+      - name: Run integration tests
+        run: go test -v ./...
+      - name: Stop local S3
+        if: always()
+        run: docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,13 @@
 version: "3"
 services:
- localstack:
-    image: localstack/localstack
+  minio:
+    image: minio/minio:edge@sha256:373cc16a29662f3f616a8de7facff0ef085257296256c59d64b158d9a59d2bd9
     environment:
-      - SERVICES=s3
+      - MINIO_REGION_NAME=local
+      - MINIO_ROOT_USER=test
+      - MINIO_ROOT_PASSWORD=testdslocal
     ports:
-      - 4566:4566
+      - 9000:9000
+    command:
+      - server
+      - /data

--- a/s3_test.go
+++ b/s3_test.go
@@ -9,19 +9,19 @@ import (
 	dstest "github.com/ipfs/go-datastore/test"
 )
 
-func TestSuite(t *testing.T) {
+func TestSuiteLocalS3(t *testing.T) {
+	// Only run tests when LOCAL_S3 is set, since the tests are not set up for AWS S3 calls.
+	if _, localS3 := os.LookupEnv("LOCAL_S3"); !localS3 {
+		t.Skipf("skipping test suit; LOCAL_S3 is not set.")
+	}
 	// run docker-compose up in this repo in order to get a local
 	// s3 running on port 4572
-	config := Config{}
-	_, hasLocalS3 := os.LookupEnv("LOCAL_S3")
-	if hasLocalS3 {
-		config = Config{
-			RegionEndpoint: "http://localhost:4566",
-			Bucket:         "localbucketname",
-			Region:         "us-east-1",
-			AccessKey:      "localonlyac",
-			SecretKey:      "localonlysk",
-		}
+	config := Config{
+		RegionEndpoint: "http://localhost:4566",
+		Bucket:         "localbucketname",
+		Region:         "us-east-1",
+		AccessKey:      "localonlyac",
+		SecretKey:      "localonlysk",
 	}
 
 	s3ds, err := NewS3Datastore(config)
@@ -29,11 +29,8 @@ func TestSuite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if hasLocalS3 {
-		err = devMakeBucket(s3ds.S3, "localbucketname")
-		if err != nil {
-			t.Fatal(err)
-		}
+	if err = devMakeBucket(s3ds.S3, "localbucketname"); err != nil {
+		t.Fatal(err)
 	}
 
 	t.Run("basic operations", func(t *testing.T) {

--- a/s3_test.go
+++ b/s3_test.go
@@ -10,18 +10,19 @@ import (
 )
 
 func TestSuiteLocalS3(t *testing.T) {
-	// Only run tests when LOCAL_S3 is set, since the tests are not set up for AWS S3 calls.
+	// Only run tests when LOCAL_S3 is set, since the tests are only set up for a local S3 endpoint.
+	// To run tests locally, run `docker-compose up` in this repo in order to get a local S3 running
+	// on port 9000. Then run `LOCAL_S3=true go test -v ./...` to execute tests.
 	if _, localS3 := os.LookupEnv("LOCAL_S3"); !localS3 {
 		t.Skipf("skipping test suit; LOCAL_S3 is not set.")
 	}
-	// run docker-compose up in this repo in order to get a local
-	// s3 running on port 4572
+
 	config := Config{
-		RegionEndpoint: "http://localhost:4566",
+		RegionEndpoint: "http://localhost:9000",
 		Bucket:         "localbucketname",
-		Region:         "us-east-1",
-		AccessKey:      "localonlyac",
-		SecretKey:      "localonlysk",
+		Region:         "local",
+		AccessKey:      "test",
+		SecretKey:      "testdslocal",
 	}
 
 	s3ds, err := NewS3Datastore(config)


### PR DESCRIPTION
Skip the test suit when the local S3 flag is not set. This is because,
otherwise the tests will certainly fail as the required config will be
empty. Further work is needed to make tests run both on local and remote
S3. For now skip if local S3 flag is absent.

Setup CI integration tests that stands up a local S3 service and runs all
the tests. Note, this can be optimised by tagging the tests. For now run
all tests as part of integration since unit tests are very small and fast.

Use `minio` instead of `localstack` because only S3 service is needed 
and the latter is over four times bigger when it comes to container size.

Relates to:
 - https://github.com/ipfs/go-ds-s3/pull/171
 - https://github.com/orgs/ipfs/projects/12#card-58209321