### PR TITLE
Update go-ds-s3 plugin to utilize prefixes for massive rate limit improvements

### DIFF
--- a/plugin/s3ds.go
+++ b/plugin/s3ds.go
@@ -97,6 +97,14 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 				return nil, fmt.Errorf("s3ds: credentialsEndpoint not a string")
 			}
 		}
+		
+		var keySuffix string
+		if v, ok := m["keySuffix"]; ok {
+			keySuffix, ok = v.(string)
+			if !ok {
+				return nil, fmt.Errorf("s3ds: keySuffix not a string")
+			}
+		}
 
 		return &S3Config{
 			cfg: s3ds.Config{
@@ -109,6 +117,7 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 				Workers:             workers,
 				RegionEndpoint:      endpoint,
 				CredentialsEndpoint: credentialsEndpoint,
+				KeySuffix: keySuffix
 			},
 		}, nil
 	}

--- a/plugin/s3ds.go
+++ b/plugin/s3ds.go
@@ -117,7 +117,7 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 				Workers:             workers,
 				RegionEndpoint:      endpoint,
 				CredentialsEndpoint: credentialsEndpoint,
-				KeySuffix: keySuffix
+				KeySuffix: keySuffix,
 			},
 		}, nil
 	}

--- a/s3.go
+++ b/s3.go
@@ -268,7 +268,7 @@ type batchOp struct {
 }
 
 func (b *s3Batch) Put(k ds.Key, val []byte) error {
-	b.ops[k.String() + "/data"] = batchOp{
+	b.ops[k.String()] = batchOp{
 		val:    val,
 		delete: false,
 	}
@@ -276,7 +276,7 @@ func (b *s3Batch) Put(k ds.Key, val []byte) error {
 }
 
 func (b *s3Batch) Delete(k ds.Key) error {
-	b.ops[k.String() + "/data"] = batchOp{
+	b.ops[k.String()] = batchOp{
 		val:    nil,
 		delete: true,
 	}
@@ -319,7 +319,7 @@ func (b *s3Batch) Commit() error {
 	}
 
 	for _, k := range putKeys {
-		jobs <- b.newPutJob(k, b.ops[k.String() + "/data"].val)
+		jobs <- b.newPutJob(k, b.ops[k.String()].val)
 	}
 
 	if len(deleteObjs) > 0 {

--- a/s3.go
+++ b/s3.go
@@ -53,25 +53,12 @@ type Config struct {
 	RootDirectory       string
 	Workers             int
 	CredentialsEndpoint string
-	KeyTransform        func(ds.Key) string
-}
-
-func DefaultKeyTransform(k ds.Key) string {
-	return k.String()
-}
-
-// BucketSplitKeyTransform can be used to ensure each cid ends up in its own bucket
-func BucketSplitKeyTransform(k ds.Key) string {
-	return k.String() + "/data"
+	KeySuffix           string
 }
 
 func NewS3Datastore(conf Config) (*S3Bucket, error) {
 	if conf.Workers == 0 {
 		conf.Workers = defaultWorkers
-	}
-
-	if conf.KeyTransform == nil {
-		conf.KeyTransform = DefaultKeyTransform
 	}
 
 	awsConfig := aws.NewConfig()
@@ -119,7 +106,7 @@ func NewS3Datastore(conf Config) (*S3Bucket, error) {
 func (s *S3Bucket) Put(k ds.Key, value []byte) error {
 	_, err := s.S3.PutObject(&s3.PutObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(s.Config.KeyTransform(k))),
+		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
 		Body:   bytes.NewReader(value),
 	})
 	return err
@@ -132,7 +119,7 @@ func (s *S3Bucket) Sync(prefix ds.Key) error {
 func (s *S3Bucket) Get(k ds.Key) ([]byte, error) {
 	resp, err := s.S3.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(s.Config.KeyTransform(k))),
+		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
 	})
 	if err != nil {
 		if isNotFound(err) {
@@ -159,7 +146,7 @@ func (s *S3Bucket) Has(k ds.Key) (exists bool, err error) {
 func (s *S3Bucket) GetSize(k ds.Key) (size int, err error) {
 	resp, err := s.S3.HeadObject(&s3.HeadObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(s.Config.KeyTransform(k))),
+		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
 	})
 	if err != nil {
 		if s3Err, ok := err.(awserr.Error); ok && s3Err.Code() == "NotFound" {
@@ -173,7 +160,7 @@ func (s *S3Bucket) GetSize(k ds.Key) (size int, err error) {
 func (s *S3Bucket) Delete(k ds.Key) error {
 	_, err := s.S3.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(s.KeyTransform(k))),
+		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
 	})
 	if isNotFound(err) {
 		// delete is idempotent


### PR DESCRIPTION
As mentioned in: https://github.com/ipfs/go-ds-s3/issues/105, S3's rate-limiting is directly related to prefixes instead of files themselves. 

Implementing this change will change the rate limits for this plugin 

from: 3,500 PUT/COPY/POST/DELETE or 5,500 GET/HEAD requests per second **for the entire bucket**

to: 3,500 PUT/COPY/POST/DELETE or 5,500 GET/HEAD requests per second **per block in the blockstore.**

As of right now, this change will mean that previous repos using this plugin will be incompatible with this update. I would very much like to avoid forking this repo into a separately maintained pinata plugin if possible so I'm open to any suggestions on how to best approach this. 