### PR TITLE
Add key transform functions for massive rate limit improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ipfs/go-ds-s3
+module github.com/3box/go-ds-s3
 
 require (
 	github.com/aws/aws-sdk-go v1.35.30

--- a/plugin/main/main.go
+++ b/plugin/main/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	plugin "github.com/ipfs/go-ds-s3/plugin"
+	plugin "github.com/3box/go-ds-s3/plugin"
 )
 
 var Plugins = plugin.Plugins //nolint

--- a/plugin/s3ds.go
+++ b/plugin/s3ds.go
@@ -97,6 +97,14 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 				return nil, fmt.Errorf("s3ds: credentialsEndpoint not a string")
 			}
 		}
+		
+		var keySuffix string
+		if v, ok := m["keySuffix"]; ok {
+			keySuffix, ok = v.(string)
+			if !ok {
+				return nil, fmt.Errorf("s3ds: keySuffix not a string")
+			}
+		}
 
 		return &S3Config{
 			cfg: s3ds.Config{
@@ -109,6 +117,7 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 				Workers:             workers,
 				RegionEndpoint:      endpoint,
 				CredentialsEndpoint: credentialsEndpoint,
+				KeySuffix: keySuffix
 			},
 		}, nil
 	}

--- a/plugin/s3ds.go
+++ b/plugin/s3ds.go
@@ -98,12 +98,12 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 			}
 		}
 
-		var keyTransform s3ds.KeyTransform
+		var keyTransform string
 		if v, ok := m["keyTransform"]; ok {
 			if v == "" {
 				keyTransform = "default"
 			} else {
-				keyTransform, ok = v.(s3ds.KeyTransform)
+				keyTransform, ok = v.(string)
 				if !ok {
 					return nil, fmt.Errorf("s3ds: keyTransform is not a valid key transform method")
 				}

--- a/plugin/s3ds.go
+++ b/plugin/s3ds.go
@@ -98,11 +98,15 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 			}
 		}
 
-		var keySuffix string
-		if v, ok := m["keySuffix"]; ok {
-			keySuffix, ok = v.(string)
-			if !ok {
-				return nil, fmt.Errorf("s3ds: keySuffix not a string")
+		var keyTransform s3ds.KeyTransform
+		if v, ok := m["keyTransform"]; ok {
+			if v == "" {
+				keyTransform = "default"
+			} else {
+				keyTransform, ok = v.(s3ds.KeyTransform)
+				if !ok {
+					return nil, fmt.Errorf("s3ds: keyTransform is not a valid key transform method")
+				}
 			}
 		}
 
@@ -117,7 +121,7 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 				Workers:             workers,
 				RegionEndpoint:      endpoint,
 				CredentialsEndpoint: credentialsEndpoint,
-				KeySuffix:           keySuffix,
+				KeyTransform:        keyTransform,
 			},
 		}, nil
 	}

--- a/plugin/s3ds.go
+++ b/plugin/s3ds.go
@@ -117,7 +117,7 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 				Workers:             workers,
 				RegionEndpoint:      endpoint,
 				CredentialsEndpoint: credentialsEndpoint,
-				KeySuffix: keySuffix
+				KeySuffix: keySuffix,
 			},
 		}, nil
 	}

--- a/plugin/s3ds.go
+++ b/plugin/s3ds.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"fmt"
 
-	s3ds "github.com/ipfs/go-ds-s3"
+	s3ds "github.com/3box/go-ds-s3"
 	"github.com/ipfs/go-ipfs/plugin"
 	"github.com/ipfs/go-ipfs/repo"
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
@@ -97,7 +97,7 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 				return nil, fmt.Errorf("s3ds: credentialsEndpoint not a string")
 			}
 		}
-		
+
 		var keySuffix string
 		if v, ok := m["keySuffix"]; ok {
 			keySuffix, ok = v.(string)
@@ -117,7 +117,7 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 				Workers:             workers,
 				RegionEndpoint:      endpoint,
 				CredentialsEndpoint: credentialsEndpoint,
-				KeySuffix: keySuffix,
+				KeySuffix:           keySuffix,
 			},
 		}, nil
 	}

--- a/plugin/s3ds_test.go
+++ b/plugin/s3ds_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	s3ds "github.com/ipfs/go-ds-s3"
+	s3ds "github.com/3box/go-ds-s3"
 )
 
 func TestS3PluginDatastoreConfigParser(t *testing.T) {

--- a/s3.go
+++ b/s3.go
@@ -63,7 +63,7 @@ var KeyTransforms = map[string]func(ds.Key) string{
 	"suffix": func(k ds.Key) string {
 		return k.String() + "/data"
 	},
-	"nextToLast2": func(k ds.Key) string {
+	"next-to-last/2": func(k ds.Key) string {
 		s := k.String()
 		offset := 1
 		start := len(s) - 2 - offset

--- a/s3.go
+++ b/s3.go
@@ -53,7 +53,7 @@ type Config struct {
 	RootDirectory       string
 	Workers             int
 	CredentialsEndpoint string
-	KeyTransform        KeyTransform
+	KeyTransform        string
 }
 
 type KeyTransform string
@@ -64,14 +64,14 @@ const (
 	NextToLast2              = "next-to-last/2"
 )
 
-var KeyTransforms = map[KeyTransform]func(ds.Key) string{
-	Default: func(k ds.Key) string {
+var KeyTransforms = map[string]func(ds.Key) string{
+	"default": func(k ds.Key) string {
 		return k.String()
 	},
-	Suffix: func(k ds.Key) string {
+	"suffix": func(k ds.Key) string {
 		return k.String() + "/data"
 	},
-	NextToLast2: func(k ds.Key) string {
+	"nextToLast2": func(k ds.Key) string {
 		s := k.String()
 		offset := 1
 		start := len(s) - 2 - offset

--- a/s3.go
+++ b/s3.go
@@ -56,14 +56,6 @@ type Config struct {
 	KeyTransform        string
 }
 
-type KeyTransform string
-
-const (
-	Default     KeyTransform = "default"
-	Suffix                   = "suffix"
-	NextToLast2              = "next-to-last/2"
-)
-
 var KeyTransforms = map[string]func(ds.Key) string{
 	"default": func(k ds.Key) string {
 		return k.String()

--- a/s3.go
+++ b/s3.go
@@ -268,7 +268,7 @@ type batchOp struct {
 }
 
 func (b *s3Batch) Put(k ds.Key, val []byte) error {
-	b.ops[k.String() + "/data"] = batchOp{
+	b.ops[k.String()] = batchOp{
 		val:    val,
 		delete: false,
 	}
@@ -276,7 +276,7 @@ func (b *s3Batch) Put(k ds.Key, val []byte) error {
 }
 
 func (b *s3Batch) Delete(k ds.Key) error {
-	b.ops[k.String() + "/data"] = batchOp{
+	b.ops[k.String()] = batchOp{
 		val:    nil,
 		delete: true,
 	}
@@ -319,7 +319,7 @@ func (b *s3Batch) Commit() error {
 	}
 
 	for _, k := range putKeys {
-		jobs <- b.newPutJob(k, b.ops[k.String() + "/data"].val)
+		jobs <- b.newPutJob(k, b.ops[k.String()].val)
 	}
 
 	if len(deleteObjs) > 0 {

--- a/s3.go
+++ b/s3.go
@@ -53,25 +53,12 @@ type Config struct {
 	RootDirectory       string
 	Workers             int
 	CredentialsEndpoint string
-	KeyTransform        func(ds.Key) string
-}
-
-func DefaultKeyTransform(k ds.Key) string {
-	return k.String()
-}
-
-// BucketSplitKeyTransform can be used to ensure each cid ends up in its own bucket
-func BucketSplitKeyTransform(k ds.Key) string {
-	return k.String() + "/data"
+	KeySuffix           string
 }
 
 func NewS3Datastore(conf Config) (*S3Bucket, error) {
 	if conf.Workers == 0 {
 		conf.Workers = defaultWorkers
-	}
-
-	if conf.KeyTransform == nil {
-		conf.KeyTransform = DefaultKeyTransform
 	}
 
 	awsConfig := aws.NewConfig()
@@ -119,7 +106,7 @@ func NewS3Datastore(conf Config) (*S3Bucket, error) {
 func (s *S3Bucket) Put(k ds.Key, value []byte) error {
 	_, err := s.S3.PutObject(&s3.PutObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(s.Config.KeyTransform(k))),
+		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
 		Body:   bytes.NewReader(value),
 	})
 	return err
@@ -132,7 +119,7 @@ func (s *S3Bucket) Sync(prefix ds.Key) error {
 func (s *S3Bucket) Get(k ds.Key) ([]byte, error) {
 	resp, err := s.S3.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(s.Config.KeyTransform(k))),
+		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
 	})
 	if err != nil {
 		if isNotFound(err) {
@@ -159,7 +146,7 @@ func (s *S3Bucket) Has(k ds.Key) (exists bool, err error) {
 func (s *S3Bucket) GetSize(k ds.Key) (size int, err error) {
 	resp, err := s.S3.HeadObject(&s3.HeadObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(s.Config.KeyTransform(k))),
+		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
 	})
 	if err != nil {
 		if s3Err, ok := err.(awserr.Error); ok && s3Err.Code() == "NotFound" {
@@ -173,7 +160,7 @@ func (s *S3Bucket) GetSize(k ds.Key) (size int, err error) {
 func (s *S3Bucket) Delete(k ds.Key) error {
 	_, err := s.S3.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(s.KeyTransform(k))),
+		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
 	})
 	if isNotFound(err) {
 		// delete is idempotent


### PR DESCRIPTION
This is simply an extension of the work @obo20 did in this PR https://github.com/ipfs/go-ds-s3/pull/195

It incorporates the suggestion made by @whyrusleeping https://github.com/ipfs/go-ds-s3/pull/195#issuecomment-900466233 to allow a key transform function to be specified such that developers can decide the layout of their data on S3.

In particular, I included the [`next-to-last/2`](https://github.com/ipfs/js-datastore-core/blob/master/src/shard-readme.js) method used in the [js-datastore-s3](https://github.com/ipfs/js-datastore-s3) to make it possible to use go-ipfs or js-ipfs over the same datastore.