### PR TITLE
force enable CGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ go.mod: FORCE
 FORCE:
 
 s3plugin.so: plugin/main/main.go go.mod
-	$(GOCC) build $(GOFLAGS) -buildmode=plugin -o "$@" "$<"
+	CGO_ENABLED=1 $(GOCC) build $(GOFLAGS) -buildmode=plugin -o "$@" "$<"
 	chmod +x "$@"
 
 build: s3plugin.so


### PR DESCRIPTION
This is required for plugins to work. It should be enabled by default, but apparently not in all cases.

fixes #213