### PR TITLE
fix bundling instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ As go plugins can be finicky to correctly compile and install, you may want to c
 > go get github.com/ipfs/go-ds-s3@latest
 
 # Add the plugin to the preload list.
-> echo -en "\ns3ds github.com/ipfs/go-ds-s3/go-ds-s3-plugin 0" >> plugin/loader/preload_list
+> echo -en "\ns3ds github.com/ipfs/go-ds-s3/plugin 0" >> plugin/loader/preload_list
 
 # ( this first pass will fail ) Try to build kubo with the plugin
 > make build


### PR DESCRIPTION
While testing the bundling process I realized that instruction in README.md regarding to preload list was indeed wrong (as prognosed in [PR #275](https://github.com/ipfs/go-ds-s3/pull/275/files#r1401898924) ).

What doesn't work:
- `echo -en "\ns3ds github.com/ipfs/go-ds-s3/go-ds-s3-plugin 0" >> plugin/loader/preload_list`
- `echo -en "\ns3ds github.com/ipfs/go-ds-s3 0" >> plugin/loader/preload_list`

What does work:
- `echo -en "\ns3ds github.com/ipfs/go-ds-s3/plugin 0" >> plugin/loader/preload_list`

This PR is related to [issue #273](https://github.com/ipfs/go-ds-s3/issues/273).