### PR TITLE
Implement STS Web Identity Role credentials provider

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"io"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -70,7 +73,7 @@ func NewS3Datastore(conf Config) (*S3Bucket, error) {
 	}
 
 	d := defaults.Get()
-	creds := credentials.NewChainCredentials([]credentials.Provider{
+	providers := []credentials.Provider{
 		&credentials.StaticProvider{Value: credentials.Value{
 			AccessKeyID:     conf.AccessKey,
 			SecretAccessKey: conf.SecretKey,
@@ -78,11 +81,21 @@ func NewS3Datastore(conf Config) (*S3Bucket, error) {
 		}},
 		&credentials.EnvProvider{},
 		&credentials.SharedCredentialsProvider{},
+		&stscreds.WebIdentityRoleProvider{},
 		&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(sess)},
 		endpointcreds.NewProviderClient(*d.Config, d.Handlers, conf.CredentialsEndpoint,
 			func(p *endpointcreds.Provider) { p.ExpiryWindow = credsRefreshWindow },
 		),
-	})
+	}
+
+	if len(os.Getenv("AWS_ROLE_ARN")) > 0 && len(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")) > 0 {
+		stsClient := sts.New(sess)
+		stsProvider := stscreds.NewWebIdentityRoleProviderWithOptions(stsClient, os.Getenv("AWS_ROLE_ARN"), "", stscreds.FetchTokenPath(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")))
+		// prepend sts provider to list of providers
+		providers = append([]credentials.Provider{stsProvider}, providers...)
+	}
+
+	creds := credentials.NewChainCredentials(providers)
 
 	if conf.RegionEndpoint != "" {
 		awsConfig.WithS3ForcePathStyle(true)

--- a/s3.go
+++ b/s3.go
@@ -81,7 +81,6 @@ func NewS3Datastore(conf Config) (*S3Bucket, error) {
 		}},
 		&credentials.EnvProvider{},
 		&credentials.SharedCredentialsProvider{},
-		&stscreds.WebIdentityRoleProvider{},
 		&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(sess)},
 		endpointcreds.NewProviderClient(*d.Config, d.Handlers, conf.CredentialsEndpoint,
 			func(p *endpointcreds.Provider) { p.ExpiryWindow = credsRefreshWindow },


### PR DESCRIPTION
# What this PR does
AWS credentials array will have STS Web Identity token provider as the first option if `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` are available and non-empty in environment.

# Motivation
One of the common ways to provide S3 (or any AWS related service) access to a pod in EKS is to annotate k8s service account with specified IAM Role. Then AWS Web Identity token gets mounted to the pod and `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` environment variables are provided automatically to the pod.

This PR enables use of these credentials.