### PR TITLE
chore: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         mv go-ds-s3-plugin/go-ds-s3-plugin.tar.gz "$NAME"
         echo "ARTIFACT_NAME=$NAME" >> "$GITHUB_ENV"
     - name: Archive artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: go-ds-s3-plugin_*.tar.gz
@@ -76,7 +76,7 @@ jobs:
         echo PLUGIN_ARTIFACT=go-ds-s3-plugin_${RELEASE}_${GOHOSTOS}_amd64.tar.gz >> "$GITHUB_ENV"
     - name: Download artifact
       id: download
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ env.PLUGIN_ARTIFACT }}
     - name: Download unpack Kubo
@@ -102,7 +102,7 @@ jobs:
     steps:
     - name: Download artifacts
       id: download
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
     - name: Extract release name from tag
       run: |
         RELEASE=$(basename ${{ github.ref_name }})


### PR DESCRIPTION
v3 is no longer supported as per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/