### PR TITLE
chore: replace ubuntu-20.04 with ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
 # macos test fail with dist-built ipfs.
 #          - macos-latest
     runs-on: ${{ matrix.os }}
@@ -98,7 +98,7 @@ jobs:
   release:
     name: "Release"
     needs: test-artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Download artifacts
       id: download


### PR DESCRIPTION
ubuntu-20.04 is getting deprecated in March - https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

ubuntu-latest now points to version 24.04