### PR TITLE
docs: add maintainer notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # S3 Datastore Implementation
 
+> [!WARNING]
+> ## 🚧 Looking for Maintainers 🚧
+>
+> This is an opt-in datastore implementation for those who need S3-compatible storage backends.
+> The project is in need of active maintenance from people who are actually using it. If you are interested in maintaining this datastore implementation, please reach out to devrel@ipfs.tech.
+
 This is an implementation of the datastore interface backed by amazon s3.
 
 **NOTE:** Plugins only work on Linux and MacOS at the moment. You can track the progress of this issue here: https://github.com/golang/go/issues/19282


### PR DESCRIPTION
Seeking active maintenance from actual S3 datastore users who have a financial incentive to keep this project alive AND optimized to minimize AWS billing.

### Rationale

Setting expectations. Right now people assume this project is actively maintained. 

Kubo does not use this backend, and our legacy collab cluster has no instance that is using S3 backend.
Lack of dogfooding means we are unable to properly triage issues / PRs in the long term, nor ensure performance / quality / cost-effectiveness.

cc @mishmosh @aschmahmann  if you know companies / startups / projects that use S3 and could lend engineering time for this